### PR TITLE
Fix crashing when updating UI from non-UI thread

### DIFF
--- a/src/CameraTF/MainActivity.cs
+++ b/src/CameraTF/MainActivity.cs
@@ -51,7 +51,7 @@ namespace CameraTF
 
         public static void ReloadCanvas()
         {
-            canvasView.Invalidate();
+            canvasView.postInvalidate();
         }
 
         private void LoadModelLabels()


### PR DESCRIPTION
I found crashing problem when calling `canvasView.Invalidate(); << MainActivity.ReloadCanvas(); << CameraAnalyzer.cs`. `Invalidate()` method should be replaced with `postInvalidate()` when calling from a non-UI thread.

Related to this issue: [https://github.com/jacano/CameraTF/issues/1](https://github.com/jacano/CameraTF/issues/1)